### PR TITLE
Support actix-web 2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,14 @@ exclude = [".travis.yml", ".gitignore"]
 edition = "2018"
 
 [dependencies]
-actix-web = { version = "^1.0", default_features = false }
-actix-service = "0.4.0"
-futures = "0.1"
-futures-locks = "0.3.3"
+actix-web = { version = "^2.0", default_features = false }
+actix-service = "1.0"
+futures = "0.3"
 bytes = "0.4"
 base64 = "0.10"
+
+[dev-dependencies]
+actix-rt = "1.0"
 
 [features]
 default = []

--- a/examples/middleware-closure.rs
+++ b/examples/middleware-closure.rs
@@ -1,18 +1,19 @@
 use actix_web::{middleware, web, App, HttpServer};
 
-use futures::future;
-
 use actix_web_httpauth::middleware::HttpAuthentication;
 
-fn main() -> std::io::Result<()> {
+#[actix_rt::main]
+async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
-        let auth = HttpAuthentication::basic(|req, _credentials| future::ok(req));
+        let auth =
+            HttpAuthentication::basic(|req, _credentials| async { Ok(req) });
         App::new()
             .wrap(middleware::Logger::default())
             .wrap(auth)
-            .service(web::resource("/").to(|| "Test\r\n"))
+            .service(web::resource("/").to(|| async { "Test\r\n" }))
     })
     .bind("127.0.0.1:8080")?
     .workers(1)
     .run()
+    .await
 }

--- a/examples/middleware.rs
+++ b/examples/middleware.rs
@@ -1,27 +1,27 @@
 use actix_web::dev::ServiceRequest;
 use actix_web::{middleware, web, App, Error, HttpServer};
 
-use futures::future;
-
 use actix_web_httpauth::extractors::basic::BasicAuth;
 use actix_web_httpauth::middleware::HttpAuthentication;
 
-fn validator(
+async fn validator(
     req: ServiceRequest,
     _credentials: BasicAuth,
-) -> future::FutureResult<ServiceRequest, Error> {
-    future::ok(req)
+) -> Result<ServiceRequest, Error> {
+    Ok(req)
 }
 
-fn main() -> std::io::Result<()> {
+#[actix_rt::main]
+async fn main() -> std::io::Result<()> {
     HttpServer::new(|| {
         let auth = HttpAuthentication::basic(validator);
         App::new()
             .wrap(middleware::Logger::default())
             .wrap(auth)
-            .service(web::resource("/").to(|| "Test\r\n"))
+            .service(web::resource("/").to(|| async { "Test\r\n" }))
     })
     .bind("127.0.0.1:8080")?
     .workers(1)
     .run()
+    .await
 }

--- a/src/extractors/basic.rs
+++ b/src/extractors/basic.rs
@@ -5,6 +5,7 @@ use std::borrow::Cow;
 use actix_web::dev::{Payload, ServiceRequest};
 use actix_web::http::header::Header;
 use actix_web::{FromRequest, HttpRequest};
+use futures::future;
 
 use super::config::AuthExtractorConfig;
 use super::errors::AuthenticationError;
@@ -57,7 +58,7 @@ impl AuthExtractorConfig for Config {
 /// use actix_web::Result;
 /// use actix_web_httpauth::extractors::basic::BasicAuth;
 ///
-/// fn index(auth: BasicAuth) -> String {
+/// async fn index(auth: BasicAuth) -> String {
 ///     format!("Hello, {}!", auth.user_id())
 /// }
 /// ```
@@ -72,7 +73,7 @@ impl AuthExtractorConfig for Config {
 /// use actix_web::{web, App};
 /// use actix_web_httpauth::extractors::basic::{BasicAuth, Config};
 ///
-/// fn index(auth: BasicAuth) -> String {
+/// async fn index(auth: BasicAuth) -> String {
 ///     format!("Hello, {}!", auth.user_id())
 /// }
 ///
@@ -101,7 +102,7 @@ impl BasicAuth {
 }
 
 impl FromRequest for BasicAuth {
-    type Future = Result<Self, Self::Error>;
+    type Future = future::Ready<Result<Self, Self::Error>>;
     type Config = Config;
     type Error = AuthenticationError<Challenge>;
 
@@ -109,37 +110,41 @@ impl FromRequest for BasicAuth {
         req: &HttpRequest,
         _: &mut Payload,
     ) -> <Self as FromRequest>::Future {
-        Authorization::<Basic>::parse(req)
-            .map(|auth| BasicAuth(auth.into_scheme()))
-            .map_err(|_| {
-                // TODO: debug! the original error
-                let challenge = req
-                    .app_data::<Self::Config>()
-                    .map(|config| config.0.clone())
-                    // TODO: Add trace! about `Default::default` call
-                    .unwrap_or_else(Default::default);
+        future::ready(
+            Authorization::<Basic>::parse(req)
+                .map(|auth| BasicAuth(auth.into_scheme()))
+                .map_err(|_| {
+                    // TODO: debug! the original error
+                    let challenge = req
+                        .app_data::<Self::Config>()
+                        .map(|config| config.0.clone())
+                        // TODO: Add trace! about `Default::default` call
+                        .unwrap_or_else(Default::default);
 
-                AuthenticationError::new(challenge)
-            })
+                    AuthenticationError::new(challenge)
+                }),
+        )
     }
 }
 
 impl AuthExtractor for BasicAuth {
     type Error = AuthenticationError<Challenge>;
-    type Future = Result<Self, Self::Error>;
+    type Future = future::Ready<Result<Self, Self::Error>>;
 
     fn from_service_request(req: &ServiceRequest) -> Self::Future {
-        Authorization::<Basic>::parse(req)
-            .map(|auth| BasicAuth(auth.into_scheme()))
-            .map_err(|_| {
-                // TODO: debug! the original error
-                let challenge = req
-                    .app_data::<Config>()
-                    .map(|config| config.0.clone())
-                    // TODO: Add trace! about `Default::default` call
-                    .unwrap_or_else(Default::default);
+        future::ready(
+            Authorization::<Basic>::parse(req)
+                .map(|auth| BasicAuth(auth.into_scheme()))
+                .map_err(|_| {
+                    // TODO: debug! the original error
+                    let challenge = req
+                        .app_data::<Config>()
+                        .map(|config| config.0.clone())
+                        // TODO: Add trace! about `Default::default` call
+                        .unwrap_or_else(Default::default);
 
-                AuthenticationError::new(challenge)
-            })
+                    AuthenticationError::new(challenge)
+                }),
+        )
     }
 }

--- a/src/extractors/bearer.rs
+++ b/src/extractors/bearer.rs
@@ -6,6 +6,7 @@ use std::default::Default;
 use actix_web::dev::{Payload, ServiceRequest};
 use actix_web::http::header::Header;
 use actix_web::{FromRequest, HttpRequest};
+use futures::future;
 
 use super::config::AuthExtractorConfig;
 use super::errors::AuthenticationError;
@@ -60,7 +61,7 @@ impl AuthExtractorConfig for Config {
 /// ```rust
 /// use actix_web_httpauth::extractors::bearer::BearerAuth;
 ///
-/// fn index(auth: BearerAuth) -> String {
+/// async fn index(auth: BearerAuth) -> String {
 ///     format!("Hello, user with token {}!", auth.token())
 /// }
 /// ```
@@ -75,7 +76,7 @@ impl AuthExtractorConfig for Config {
 /// use actix_web::{web, App};
 /// use actix_web_httpauth::extractors::bearer::{BearerAuth, Config};
 ///
-/// fn index(auth: BearerAuth) -> String {
+/// async fn index(auth: BearerAuth) -> String {
 ///     format!("Hello, {}!", auth.token())
 /// }
 ///
@@ -101,41 +102,45 @@ impl BearerAuth {
 
 impl FromRequest for BearerAuth {
     type Config = Config;
-    type Future = Result<Self, Self::Error>;
+    type Future = future::Ready<Result<Self, Self::Error>>;
     type Error = AuthenticationError<bearer::Bearer>;
 
     fn from_request(
         req: &HttpRequest,
         _payload: &mut Payload,
     ) -> <Self as FromRequest>::Future {
-        authorization::Authorization::<authorization::Bearer>::parse(req)
-            .map(|auth| BearerAuth(auth.into_scheme()))
-            .map_err(|_| {
-                let bearer = req
-                    .app_data::<Self::Config>()
-                    .map(|config| config.0.clone())
-                    .unwrap_or_else(Default::default);
+        future::ready(
+            authorization::Authorization::<authorization::Bearer>::parse(req)
+                .map(|auth| BearerAuth(auth.into_scheme()))
+                .map_err(|_| {
+                    let bearer = req
+                        .app_data::<Self::Config>()
+                        .map(|config| config.0.clone())
+                        .unwrap_or_else(Default::default);
 
-                AuthenticationError::new(bearer)
-            })
+                    AuthenticationError::new(bearer)
+                }),
+        )
     }
 }
 
 impl AuthExtractor for BearerAuth {
-    type Future = Result<Self, Self::Error>;
+    type Future = future::Ready<Result<Self, Self::Error>>;
     type Error = AuthenticationError<bearer::Bearer>;
 
     fn from_service_request(req: &ServiceRequest) -> Self::Future {
-        authorization::Authorization::<authorization::Bearer>::parse(req)
-            .map(|auth| BearerAuth(auth.into_scheme()))
-            .map_err(|_| {
-                let bearer = req
-                    .app_data::<Config>()
-                    .map(|config| config.0.clone())
-                    .unwrap_or_else(Default::default);
+        future::ready(
+            authorization::Authorization::<authorization::Bearer>::parse(req)
+                .map(|auth| BearerAuth(auth.into_scheme()))
+                .map_err(|_| {
+                    let bearer = req
+                        .app_data::<Config>()
+                        .map(|config| config.0.clone())
+                        .unwrap_or_else(Default::default);
 
-                AuthenticationError::new(bearer)
-            })
+                    AuthenticationError::new(bearer)
+                }),
+        )
     }
 }
 

--- a/src/extractors/mod.rs
+++ b/src/extractors/mod.rs
@@ -2,7 +2,7 @@
 
 use actix_web::dev::ServiceRequest;
 use actix_web::Error;
-use futures::IntoFuture;
+use futures::future::Future;
 
 pub mod basic;
 pub mod bearer;
@@ -26,7 +26,7 @@ pub trait AuthExtractor: Sized {
     type Error: Into<Error>;
 
     /// Future that resolves into extracted credentials type.
-    type Future: IntoFuture<Item = Self, Error = Self::Error>;
+    type Future: Future<Output = Result<Self, Self::Error>>;
 
     /// Parse the authentication credentials from the actix' `ServiceRequest`.
     fn from_service_request(req: &ServiceRequest) -> Self::Future;

--- a/src/headers/authorization/scheme/basic.rs
+++ b/src/headers/authorization/scheme/basic.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::str;
 
 use actix_web::http::header::{
-    HeaderValue, IntoHeaderValue, InvalidHeaderValueBytes,
+    HeaderValue, IntoHeaderValue, InvalidHeaderValue,
 };
 use base64;
 use bytes::{BufMut, BytesMut};
@@ -101,7 +101,7 @@ impl fmt::Display for Basic {
 }
 
 impl IntoHeaderValue for Basic {
-    type Error = InvalidHeaderValueBytes;
+    type Error = InvalidHeaderValue;
 
     fn try_into(self) -> Result<HeaderValue, <Self as IntoHeaderValue>::Error> {
         let mut credentials = BytesMut::with_capacity(
@@ -123,7 +123,7 @@ impl IntoHeaderValue for Basic {
         value.put("Basic ");
         value.put(&encoded);
 
-        HeaderValue::from_shared(value.freeze())
+        HeaderValue::from_maybe_shared(value.freeze())
     }
 }
 

--- a/src/headers/authorization/scheme/bearer.rs
+++ b/src/headers/authorization/scheme/bearer.rs
@@ -2,7 +2,7 @@ use std::borrow::Cow;
 use std::fmt;
 
 use actix_web::http::header::{
-    HeaderValue, IntoHeaderValue, InvalidHeaderValueBytes,
+    HeaderValue, IntoHeaderValue, InvalidHeaderValue,
 };
 use bytes::{BufMut, BytesMut};
 
@@ -76,14 +76,14 @@ impl fmt::Display for Bearer {
 }
 
 impl IntoHeaderValue for Bearer {
-    type Error = InvalidHeaderValueBytes;
+    type Error = InvalidHeaderValue;
 
     fn try_into(self) -> Result<HeaderValue, <Self as IntoHeaderValue>::Error> {
         let mut buffer = BytesMut::with_capacity(7 + self.token.len());
         buffer.put("Bearer ");
         buffer.extend_from_slice(self.token.as_bytes());
 
-        HeaderValue::from_shared(buffer.freeze())
+        HeaderValue::from_maybe_shared(buffer.freeze())
     }
 }
 

--- a/src/headers/www_authenticate/challenge/basic.rs
+++ b/src/headers/www_authenticate/challenge/basic.rs
@@ -6,7 +6,7 @@ use std::fmt;
 use std::str;
 
 use actix_web::http::header::{
-    HeaderValue, IntoHeaderValue, InvalidHeaderValueBytes,
+    HeaderValue, IntoHeaderValue, InvalidHeaderValue,
 };
 use bytes::{BufMut, Bytes, BytesMut};
 
@@ -106,10 +106,10 @@ impl fmt::Display for Basic {
 }
 
 impl IntoHeaderValue for Basic {
-    type Error = InvalidHeaderValueBytes;
+    type Error = InvalidHeaderValue;
 
     fn try_into(self) -> Result<HeaderValue, <Self as IntoHeaderValue>::Error> {
-        HeaderValue::from_shared(self.to_bytes())
+        HeaderValue::from_maybe_shared(self.to_bytes())
     }
 }
 

--- a/src/headers/www_authenticate/challenge/bearer/challenge.rs
+++ b/src/headers/www_authenticate/challenge/bearer/challenge.rs
@@ -3,7 +3,7 @@ use std::fmt;
 use std::str;
 
 use actix_web::http::header::{
-    HeaderValue, IntoHeaderValue, InvalidHeaderValueBytes,
+    HeaderValue, IntoHeaderValue, InvalidHeaderValue,
 };
 use bytes::{BufMut, Bytes, BytesMut};
 
@@ -133,9 +133,9 @@ impl fmt::Display for Bearer {
 }
 
 impl IntoHeaderValue for Bearer {
-    type Error = InvalidHeaderValueBytes;
+    type Error = InvalidHeaderValue;
 
     fn try_into(self) -> Result<HeaderValue, <Self as IntoHeaderValue>::Error> {
-        HeaderValue::from_shared(self.to_bytes())
+        HeaderValue::from_maybe_shared(self.to_bytes())
     }
 }


### PR DESCRIPTION
This patch bumps actix-web dependency from 1.x to 2.x, while bumping futures from 0.1 to 0.3.

As the new `futures` comes with its own Mutex implementation, this patch removes futures-locks dependency too. This means that we have to use async/await to deal with lifetime-bound futures.